### PR TITLE
fix: `vali.py` 强制将模型移动到cuda

### DIFF
--- a/vali.py
+++ b/vali.py
@@ -53,7 +53,7 @@ load = torch.load(model_path,weights_only=True)
 state_dict = load['model']
 model.load_state_dict(state_dict)
 
-model = model.cuda()
+model = model.to(device)
 model.eval()
 
 


### PR DESCRIPTION
应该是 model.to(device) 吧